### PR TITLE
Forward arguments in logging functions

### DIFF
--- a/src/cpp/log.h
+++ b/src/cpp/log.h
@@ -210,7 +210,7 @@ using LogLevelFilter = fastly::sys::log::LogLevelFilter;
 template <typename... Args>
 void error(std::format_string<Args...> fmt, Args &&...args) {
   fastly::sys::log::f_log_log(fastly::sys::log::LogLevel::Error,
-                              std::format(fmt, args...));
+                              std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send an Error-level message to a specified configured endpoint.
@@ -234,7 +234,7 @@ void error_to(std::string_view dest, std::format_string<Args...> fmt,
               Args &&...args) {
   fastly::sys::log::f_log_log_to(static_cast<std::string>(dest),
                                  fastly::sys::log::LogLevel::Error,
-                                 std::format(fmt, args...));
+                                 std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send a Warn-level message to the configured default endpoint.
@@ -252,7 +252,7 @@ void error_to(std::string_view dest, std::format_string<Args...> fmt,
 template <typename... Args>
 void warn(std::format_string<Args...> fmt, Args &&...args) {
   fastly::sys::log::f_log_log(fastly::sys::log::LogLevel::Warn,
-                              std::format(fmt, args...));
+                              std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send a Warn-level message to a specified configured endpoint.
@@ -276,7 +276,7 @@ void warn_to(std::string_view dest, std::format_string<Args...> fmt,
              Args &&...args) {
   fastly::sys::log::f_log_log_to(static_cast<std::string>(dest),
                                  fastly::sys::log::LogLevel::Warn,
-                                 std::format(fmt, args...));
+                                 std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send an Info-level message to the configured default endpoint.
@@ -318,7 +318,7 @@ void info_to(std::string_view dest, std::format_string<Args...> fmt,
              Args &&...args) {
   fastly::sys::log::f_log_log_to(static_cast<std::string>(dest),
                                  fastly::sys::log::LogLevel::Info,
-                                 std::format(fmt, args...));
+                                 std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send a Debug-level message to the configured default endpoint.
@@ -336,7 +336,7 @@ void info_to(std::string_view dest, std::format_string<Args...> fmt,
 template <typename... Args>
 void debug(std::format_string<Args...> fmt, Args &&...args) {
   fastly::sys::log::f_log_log(fastly::sys::log::LogLevel::Debug,
-                              std::format(fmt, args...));
+                              std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send a Debug-level message to a specified configured endpoint.
@@ -360,7 +360,7 @@ void debug_to(std::string_view dest, std::format_string<Args...> fmt,
               Args &&...args) {
   fastly::sys::log::f_log_log_to(static_cast<std::string>(dest),
                                  fastly::sys::log::LogLevel::Debug,
-                                 std::format(fmt, args...));
+                                 std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send a Trace-level message to the configured default endpoint.
@@ -378,7 +378,7 @@ void debug_to(std::string_view dest, std::format_string<Args...> fmt,
 template <typename... Args>
 void trace(std::format_string<Args...> fmt, Args &&...args) {
   fastly::sys::log::f_log_log(fastly::sys::log::LogLevel::Trace,
-                              std::format(fmt, args...));
+                              std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Send a Trace-level message to a specified configured endpoint.
@@ -402,7 +402,7 @@ void trace_to(std::string_view dest, std::format_string<Args...> fmt,
               Args &&...args) {
   fastly::sys::log::f_log_log_to(static_cast<std::string>(dest),
                                  fastly::sys::log::LogLevel::Trace,
-                                 std::format(fmt, args...));
+                                 std::format(fmt, std::forward<Args>(args)...));
 }
 
 /// Set the global maximum log level


### PR DESCRIPTION
Arguments to logging functions were not all `std::forward`ed. This PR makes it consistent across all logging functions.