### PR TITLE
add dev guide and make releases go live immediately

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,5 +117,3 @@ jobs:
           artifactErrorsFailBuild: true
           artifactContentType: "application/gzip"
           generateReleaseNotes: true
-          draft: true
-          prerelease: true

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,23 @@
+# Developer's Guide
+
+This document includes notes for devs of the SDK itself. This is largely for
+things involving releases, architecture, etc. See
+[CONTRIBUTING.md](./CONTRIBUTING.md) for docs meant for contributors to get up
+and running enough to send in pull requests.
+
+## Releasing
+
+We use [this workflow](./.github/workflows/release.yml) to mostly automate
+releases. New releases are a three-step process:
+
+1. Go to [the list of closed
+   PRs](https://github.com/fastly/compute-sdk-cpp/pulls?q=is%3Apr%20is%3Aclosed)
+   and make sure they all have appropriate labels—the release system will use
+   this to generate changelogs. To see what labels map to what, refer to the
+   [Release Action config](./.github/release.yml).
+1. Locally, tag a new release, following semver conventions, prefixed with a `v`
+   (so, `v1.2.3`). Push the tag.
+
+From here, just wait for the [release
+action](https://github.com/fastly/compute-sdk-cpp/actions/workflows/release.yml)
+to complete, and you'll have a live release!


### PR DESCRIPTION
This actually documents how we do releases. In the process, I realized that making our releases default to draft+prerelease is only going to be a footgun, so I removed that, too (this was the case with 0.7.0, which sat there for a long time). If we tag something, it should be fine to release it.